### PR TITLE
Update npc_metropolice.cpp

### DIFF
--- a/src/game/server/hl2/npc_metropolice.cpp
+++ b/src/game/server/hl2/npc_metropolice.cpp
@@ -2810,6 +2810,7 @@ void CNPC_MetroPolice::OnAnimEventStartDeployManhack( void )
 	}
 
 	pManhack->Spawn();
+	pManhack->Activate();
 
 	// Make us move with his hand until we're deployed
 	pManhack->SetParent( this, handAttachment );


### PR DESCRIPTION
Issue #11 is telling us the manhack doesn't have a team if thrown by a metrocop, I believe that's because CAI_BaseNPC::Activate() isn't called to set its team regarding of its class. This pull request fixes that.

Btw your mod is awesome keep up the good work! :+1: 