### PR TITLE
Teleporters now cost 50 & drop 25 metal

### DIFF
--- a/game/tf_coop/scripts/objects.txt
+++ b/game/tf_coop/scripts/objects.txt
@@ -62,7 +62,7 @@ objects
 		StatusName			"#TF_Object_Tele_Entrance"
 		BuildTime			20
 		MaxObjects			1
-		Cost				125
+		Cost				50
 		CostMultiplier		1
 		UpgradeCost			0
 		MaxUpgradeLevel		0
@@ -81,7 +81,7 @@ objects
 		VisibleInWeaponSelection 0
 		ExplodeSound		"Building_Teleporter.Explode"
 		ExplodeEffect		"ExplosionCore_buildings"
-		MetalToDropInGibs	60
+		MetalToDropInGibs	25
 	}
 	
 	OBJ_TELEPORTER_EXIT
@@ -90,7 +90,7 @@ objects
 		StatusName			"#TF_Object_Tele_Exit"
 		BuildTime			20
 		MaxObjects			1
-		Cost				125
+		Cost				50
 		CostMultiplier		1
 		UpgradeCost			0
 		MaxUpgradeLevel		0
@@ -109,7 +109,7 @@ objects
 		VisibleInWeaponSelection 0
 		ExplodeSound		"Building_Teleporter.Explode"
 		ExplodeEffect		"ExplosionCore_buildings"
-		MetalToDropInGibs	60
+		MetalToDropInGibs	25
 	}
 	
 	OBJ_ATTACHMENT_SAPPER


### PR DESCRIPTION
This change reflects the current version of TF2 - Teleporters cost 50 metal, but only drop 25 metal now.