### PR TITLE
Several changes to the AI

### DIFF
--- a/src/game/server/ai_basenpc.h
+++ b/src/game/server/ai_basenpc.h
@@ -1676,6 +1676,11 @@ public:
 	virtual void		AddEntityRelationship( CBaseEntity *pEntity, Disposition_t nDisposition, int nPriority );
 	virtual void		AddClassRelationship( Class_T nClass, Disposition_t nDisposition, int nPriority );
 
+#ifdef TF_CLASSIC
+	Disposition_t		IRelationType(CBaseEntity *pTarget);
+	int					IRelationPriority( CBaseEntity *pTarget );
+#endif
+
 	void				NPCUse( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value );
 
 	CBaseGrenade*		IncomingGrenade(void);


### PR DESCRIPTION
I've made several changes to the NPCs to better adjust them to the presence of TF2 classes and systems. Most of them are toggle-able by a series of convars and only register if TF_CLASSIC is defined. I wasn't able to test this with multiple players, but I don't think there would be many issues in that regard. You're welcome to use this code in any way.

**lf_npc_uberfear** -- Makes NPCs fear enemies who are
invulnerable/ubercharged. If set to 2, zombies and antlions remain
fearless.
**lf_npc_prioritizemedics** -- Makes NPCs target enemy medics who are either
healing others or have an ubercharge ready. If set to 2, they will
deprioritize the target being healed.
**lf_npc_ubertactics** -- Makes NPCs, particularly humans and combine, more
aggressive when they are ubercharged.
**lf_npc_intelpriority** -- Makes NPCs prioritize players carrying intel.
**lf_npc_combine_sentrybehavior** -- Allows soldiers to employ special
tactics against sentry guns. They will become grenade-happy if they
somehow survive the first few seconds after seeing it for the first
time. If the sentry is disabled, maybe from being sapped, they will
charge it immediately. This was partially taken from their behavior
against hacked Combine turrets. _(you might want to make sure the sapping
part works)_

NPCs also do not avoid danger sounds (e.g, grenades) when they are
ubercharged, but this isn't determined by a convar. Elites don't fire
their energy balls at ubered targets either, which also isn't determind
by a convar.

I could've added other things, like NPCs taking cover at the nearest dispenser instead of the nearest doorway, but these would've required more drastic changes, including new schedules, new functions, etc. I wanted to keep things small for this pull request, but I'll be happy to do more if necessary.

I also have absolutely no idea what I'm doing.